### PR TITLE
chore: linter setup and fixes, doc changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,29 +51,74 @@ cd $HOME/go-vela/pkg-queue
 git remote add fork https://github.com/your_fork/pkg-queue
 ```
 
-### Running Locally
+### Development
 
 * Navigate to the repository code:
 
 ```bash
-# Change into the project directory
+# change into the project directory
 cd $HOME/go-vela/pkg-queue
 ```
 
-* Build the repository code:
+* Write your code and tests to implement the changes you desire.
+  * Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+  * Please address linter warnings appropriately. If you are intentionally violating a rule that triggers a linter, please annotate the respective code with `nolint` declarations [[docs](https://golangci-lint.run/usage/false-positives/)]. we are using the following format for `nolint` declarations:
+
+    ```go
+    // nolint:<linter(s)> // <short reason>
+    ```
+  
+    Example:
+
+    ```go
+    // nolint:gocyclo // legacy function is complex, needs simplification
+    func superComplexFunction() error {
+      // ..
+    }
+    ```
+
+    Check the [documentation for more examples](https://golangci-lint.run/usage/false-positives/).
+
+* Test the repository code (ensures your changes don't break existing functionality):
 
 ```bash
-# Build the code with `make`
-make build
+# execute the `test` target with `make`
+make test
 ```
 
-* Run the repository code:
+* Clean the repository code (ensures your code meets the project standards):
 
 ```bash
-# Run the code with `make`
-make run
+# execute the `test` target with `make`
+make clean
 ```
 
-### Development
+* Push to your fork:
 
-coming soon!
+```bash
+# push your code up to your fork
+git push fork master
+```
+
+* Open a pull request!
+  * For the title of the pull request, please use the following format for the title:
+
+    ```text
+    feat(wobble): add hat wobble
+    ^--^^------^  ^------------^
+    |   |         |
+    |   |         +---> Summary in present tense.
+    |   +---> Scope: a noun describing a section of the codebase (optional)
+    +---> Type: chore, docs, feat, fix, refactor, or test.
+    ```
+
+    * feat: adds a new feature (equivalent to a MINOR in Semantic Versioning)
+    * fix: fixes a bug (equivalent to a PATCH in Semantic Versioning)
+    * docs: changes to the documentation
+    * refactor: refactors production code, eg. renaming a variable; doesn't change public API
+    * test: adds missing tests, refactors tests; no production code change
+    * chore: updates something without impacting the user (ex: bump a dependency in package.json or go.mod); no production code change
+
+    If a code change introduces a breaking change, place ! suffix after type, ie. feat(change)!: adds breaking change. correlates with MAJOR in semantic versioning.
+
+Thank you for your contribution!

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,10 +56,10 @@ linters-settings:
 
   # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    allow-leading-space: true # allow non-"machine-readable" format (ie. with leading space) 
+    allow-unused: false # allow nolint directives that don't address a linting issue
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by
@@ -131,7 +131,9 @@ issues:
     # prevent linters from running on *_test.go files
     - path: _test\.go
       linters:
+        - dupl
         - funlen
         - goconst
         - gocyclo
         - gomnd
+        - lll

--- a/queue/context.go
+++ b/queue/context.go
@@ -55,6 +55,8 @@ func WithContext(c context.Context, s Service) context.Context {
 	// set the queue Service in the context.Context
 	//
 	// https://pkg.go.dev/context?tab=doc#WithValue
+	//
+	// nolint: golint,staticcheck // ignore using string with context value
 	return context.WithValue(c, key, s)
 }
 

--- a/queue/context_test.go
+++ b/queue/context_test.go
@@ -22,6 +22,7 @@ func TestExecutor_FromContext(t *testing.T) {
 		want    Service
 	}{
 		{
+			// nolint: golint,staticcheck // ignore using string with context value
 			context: context.WithValue(context.Background(), key, _service),
 			want:    _service,
 		},
@@ -30,6 +31,7 @@ func TestExecutor_FromContext(t *testing.T) {
 			want:    nil,
 		},
 		{
+			// nolint: golint,staticcheck // ignore using string with context value
 			context: context.WithValue(context.Background(), key, "foo"),
 			want:    nil,
 		},
@@ -90,6 +92,7 @@ func TestExecutor_WithContext(t *testing.T) {
 	// setup types
 	_service, _ := New(&Setup{})
 
+	// nolint: golint,staticcheck // ignore using string with context value
 	want := context.WithValue(context.Background(), key, _service)
 
 	// run test

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// nolint: godot // ignore period at end for comment ending in a list
+//
 // New creates and returns a Vela service capable of integrating
 // with the configured queue environments. Currently the
 // following queues are supported:

--- a/queue/redis/redis.go
+++ b/queue/redis/redis.go
@@ -22,6 +22,8 @@ type client struct {
 
 // New returns a Queue implementation that
 // integrates with a Redis queue instance.
+//
+// nolint: golint // ignore returning unexported client
 func New(url string, channels ...string) (*client, error) {
 	// parse the url provided
 	options, err := redis.ParseURL(url)
@@ -50,6 +52,8 @@ func New(url string, channels ...string) (*client, error) {
 
 // NewCluster returns a Queue implementation that
 // integrates with a Redis queue cluster.
+//
+// nolint: golint // ignore returning unexported client
 func NewCluster(config string, channels ...string) (*client, error) {
 	// parse the url provided
 	options, err := redis.ParseURL(config)
@@ -154,6 +158,8 @@ func pingQueue(client *redis.Client) error {
 // with the different supported backends.
 //
 // This function is intended for running tests only.
+//
+// nolint: golint // ignore returning unexported client
 func NewTest(channels ...string) (*client, error) {
 	// run a local fake redis instance
 	mr, err := miniredis.Run()

--- a/queue/redis/redis_test.go
+++ b/queue/redis/redis_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-vela/types/pipeline"
 )
 
-// setup global variables used for testing
+// setup global variables used for testing.
 var (
 	_build = &library.Build{
 		ID:           vela.Int64(1),


### PR DESCRIPTION
Continuation of the efforts from https://github.com/go-vela/mock/pull/76 and https://github.com/go-vela/types/pull/122

* Updating the contributing guide to include fixing linter warnings if any are present
* Skipping the `dupl` and `lll` linters on `*_test.go` files
* Added `nolint` directives across the repo to address any current linter issues