### PR TITLE
feat(shutdown): utilize connect timeout to allow non blocking func

### DIFF
--- a/queue/flags.go
+++ b/queue/flags.go
@@ -4,7 +4,11 @@
 
 package queue
 
-import "github.com/urfave/cli/v2"
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
 
 // Flags represents all supported command line
 // interface (CLI) flags for the queue.
@@ -41,5 +45,11 @@ var Flags = []cli.Flag{
 		EnvVars: []string{"VELA_QUEUE_WORKER_ROUTES", "QUEUE_WORKER_ROUTES"},
 		Name:    "queue.worker.routes",
 		Usage:   "queue worker routes is configuration for routing builds",
+	},
+	&cli.DurationFlag{
+		EnvVars: []string{"VELA_QUEUE_BLPOP_TIMEOUT", "QUEUE_BLPOP_TIMEOUT"},
+		Name:    "queue.worker.blpop.timeout",
+		Usage:   "queue timeout for the blpop call",
+		Value:   60 * time.Second,
 	},
 }

--- a/queue/redis/pop.go
+++ b/queue/redis/pop.go
@@ -6,7 +6,9 @@ package redis
 
 import (
 	"encoding/json"
+	"time"
 
+	"github.com/go-redis/redis"
 	"github.com/go-vela/types"
 	"github.com/sirupsen/logrus"
 )
@@ -18,14 +20,19 @@ func (c *client) Pop() (*types.Item, error) {
 	// build a redis queue command to pop an item from queue
 	//
 	// https://pkg.go.dev/github.com/go-redis/redis?tab=doc#Client.BLPop
-	popCmd := c.Queue.BLPop(0, c.Channels...)
+	popCmd := c.Queue.BLPop(60*time.Second, c.Channels...)
 
 	// blocking call to pop item from queue
 	//
 	// https://pkg.go.dev/github.com/go-redis/redis?tab=doc#StringSliceCmd.Result
 	result, err := popCmd.Result()
 	if err != nil {
-		return nil, err
+		switch err {
+		case redis.Nil: // BLPOP timeout
+			return nil, nil
+		default:
+			return nil, err
+		}
 	}
 
 	item := new(types.Item)

--- a/queue/redis/pop.go
+++ b/queue/redis/pop.go
@@ -6,7 +6,6 @@ package redis
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/go-redis/redis"
 	"github.com/go-vela/types"
@@ -20,7 +19,7 @@ func (c *client) Pop() (*types.Item, error) {
 	// build a redis queue command to pop an item from queue
 	//
 	// https://pkg.go.dev/github.com/go-redis/redis?tab=doc#Client.BLPop
-	popCmd := c.Queue.BLPop(60*time.Second, c.Channels...)
+	popCmd := c.Queue.BLPop(c.Timeout, c.Channels...)
 
 	// blocking call to pop item from queue
 	//

--- a/queue/redis/redis.go
+++ b/queue/redis/redis.go
@@ -7,6 +7,7 @@ package redis
 import (
 	"fmt"
 	"strings"
+
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
@@ -25,7 +26,7 @@ type client struct {
 // integrates with a Redis queue instance.
 //
 // nolint: golint // ignore returning unexported client
-func New(url string, channels ...string) (*client, error) {
+func New(url string, timeout time.Duration, channels ...string) (*client, error) {
 	// parse the url provided
 	options, err := redis.ParseURL(url)
 	if err != nil {
@@ -46,6 +47,7 @@ func New(url string, channels ...string) (*client, error) {
 		Queue:    queue,
 		Options:  options,
 		Channels: channels,
+		Timeout:  timeout,
 	}
 
 	return client, nil

--- a/queue/redis/redis.go
+++ b/queue/redis/redis.go
@@ -18,6 +18,7 @@ type client struct {
 	Queue    *redis.Client
 	Options  *redis.Options
 	Channels []string
+	Timeout  time.Duration
 }
 
 // New returns a Queue implementation that

--- a/queue/redis/redis_test.go
+++ b/queue/redis/redis_test.go
@@ -7,6 +7,7 @@ package redis
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/Bose/minisentinel"
 	"github.com/alicebob/miniredis/v2"
@@ -129,7 +130,7 @@ func TestRedis_New_Success(t *testing.T) {
 	uri := fmt.Sprintf("redis://%s", redis.Addr())
 
 	// run test
-	_, err := New(uri, constants.DefaultRoute)
+	_, err := New(uri, 5*time.Second, constants.DefaultRoute)
 	if err != nil {
 		t.Error("New should not have returned err: ", err)
 	}
@@ -152,7 +153,7 @@ func TestRedis_New_Failure(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		// run test
-		_, err := New(test.data, constants.DefaultRoute)
+		_, err := New(test.data, 5*time.Second, constants.DefaultRoute)
 		if err == nil {
 			t.Errorf("New should have returned err")
 		}
@@ -198,7 +199,7 @@ func TestRedis_NewCluster_Failure(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		// run test
-		_, err := New(test.data, constants.DefaultRoute)
+		_, err := New(test.data, 5*time.Second, constants.DefaultRoute)
 		if err == nil {
 			t.Errorf("New should have returned err")
 		}

--- a/queue/setup.go
+++ b/queue/setup.go
@@ -6,6 +6,7 @@ package queue
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/go-vela/pkg-queue/queue/redis"
 	"github.com/go-vela/types/constants"
@@ -24,6 +25,8 @@ type Setup struct {
 	Config string
 	// channels to listen on for the queue
 	Routes []string
+	// timeout of the Blpop connection
+	Timeout time.Duration
 }
 
 // Redis creates and returns a Vela engine capable of

--- a/queue/setup.go
+++ b/queue/setup.go
@@ -49,7 +49,7 @@ func (s *Setup) Redis() (Service, error) {
 	// create new Redis queue service
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-queue/queue/redis?tab=doc#New
-	return redis.New(s.Config, routes...)
+	return redis.New(s.Config, s.Timeout, routes...)
 }
 
 // Kafka creates and returns a Vela engine capable of
@@ -71,6 +71,10 @@ func (s *Setup) Validate() error {
 
 	if len(s.Config) == 0 {
 		return fmt.Errorf("queue.config (VELA_QUEUE_CONFIG or QUEUE_CONFIG) flag not specified")
+	}
+
+	if s.Timeout == 0 {
+		return fmt.Errorf("queue.worker.blpop.timeout (VELA_QUEUE_BLPOP_TIMEOUT or QUEUE_BLPOP_TIMEOUT) flag not specified")
 	}
 
 	// setup is valid

--- a/queue/setup.go
+++ b/queue/setup.go
@@ -73,10 +73,6 @@ func (s *Setup) Validate() error {
 		return fmt.Errorf("queue.config (VELA_QUEUE_CONFIG or QUEUE_CONFIG) flag not specified")
 	}
 
-	if s.Timeout == 0 {
-		return fmt.Errorf("queue.worker.blpop.timeout (VELA_QUEUE_BLPOP_TIMEOUT or QUEUE_BLPOP_TIMEOUT) flag not specified")
-	}
-
 	// setup is valid
 	return nil
 }


### PR DESCRIPTION
Adding a request timeout to the [BLPOP](https://redis.io/commands/blpop) to prevent indefinite blocking, thus allowing the worker to gracefully shutdown.

Needed for https://github.com/go-vela/community/issues/64.