### PR TITLE
refactor(redis): add ClientOpt{} and update New() to accept ...ClientOpt{}

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -116,7 +116,6 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
 github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
@@ -151,7 +150,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
-github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
 github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/queue/redis/opts.go
+++ b/queue/redis/opts.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package redis
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ClientOpt represents a configuration option to initialize the queue client.
+type ClientOpt func(*client) error
+
+// WithAddress sets the Redis address in the queue client.
+func WithAddress(address string) ClientOpt {
+	logrus.Trace("configuring address in redis queue client")
+
+	return func(c *client) error {
+		// check if the address provided is empty
+		if len(address) == 0 {
+			return fmt.Errorf("no Redis queue address provided")
+		}
+
+		// set the queue address in the redis client
+		c.config.Address = address
+
+		return nil
+	}
+}
+
+// WithChannels sets the Redis channels in the queue client.
+func WithChannels(channels ...string) ClientOpt {
+	logrus.Trace("configuring channels in redis queue client")
+
+	return func(c *client) error {
+		// check if the channels provided are empty
+		if len(channels) == 0 {
+			return fmt.Errorf("no Redis queue channels provided")
+		}
+
+		// set the queue channels in the redis client
+		c.config.Channels = channels
+
+		return nil
+	}
+}
+
+// WithCluster sets the Redis clustering mode in the queue client.
+func WithCluster(cluster bool) ClientOpt {
+	logrus.Trace("configuring clustering mode in redis queue client")
+
+	return func(c *client) error {
+		// set the queue clustering mode in the redis client
+		c.config.Cluster = cluster
+
+		return nil
+	}
+}

--- a/queue/redis/opts_test.go
+++ b/queue/redis/opts_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package redis
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/Bose/minisentinel"
+	"github.com/alicebob/miniredis/v2"
+)
+
+func TestRedis_ClientOpt_WithAddress(t *testing.T) {
+	// setup tests
+
+	// create a local fake redis instance
+	//
+	// https://pkg.go.dev/github.com/alicebob/miniredis/v2#Run
+	_redis, err := miniredis.Run()
+	if err != nil {
+		t.Errorf("unable to create miniredis instance: %v", err)
+	}
+	defer _redis.Close()
+
+	tests := []struct {
+		failure bool
+		address string
+		want    string
+	}{
+		{
+			failure: false,
+			address: fmt.Sprintf("redis://%s", _redis.Addr()),
+			want:    fmt.Sprintf("redis://%s", _redis.Addr()),
+		},
+		{
+			failure: true,
+			address: "",
+			want:    "",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_service, err := New(
+			WithAddress(test.address),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithAddress should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithAddress returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_service.config.Address, test.want) {
+			t.Errorf("WithAddress is %v, want %v", _service.config.Address, test.want)
+		}
+	}
+}
+
+func TestRedis_ClientOpt_WithChannels(t *testing.T) {
+	// setup tests
+
+	// create a local fake redis instance
+	//
+	// https://pkg.go.dev/github.com/alicebob/miniredis/v2#Run
+	_redis, err := miniredis.Run()
+	if err != nil {
+		t.Errorf("unable to create miniredis instance: %v", err)
+	}
+	defer _redis.Close()
+
+	tests := []struct {
+		failure  bool
+		channels []string
+		want     []string
+	}{
+		{
+			failure:  false,
+			channels: []string{"foo", "bar"},
+			want:     []string{"foo", "bar"},
+		},
+		{
+			failure:  true,
+			channels: []string{},
+			want:     []string{},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_service, err := New(
+			WithAddress(fmt.Sprintf("redis://%s", _redis.Addr())),
+			WithChannels(test.channels...),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithChannels should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithChannels returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_service.config.Channels, test.want) {
+			t.Errorf("WithChannels is %v, want %v", _service.config.Channels, test.want)
+		}
+	}
+}
+
+func TestRedis_ClientOpt_WithCluster(t *testing.T) {
+	// setup tests
+
+	// create a local fake redis instance
+	//
+	// https://pkg.go.dev/github.com/alicebob/miniredis/v2#Run
+	_primary, err := miniredis.Run()
+	if err != nil {
+		t.Errorf("unable to create primary miniredis instance: %v", err)
+	}
+	defer _primary.Close()
+
+	// create a local fake redis instance
+	//
+	// https://pkg.go.dev/github.com/alicebob/miniredis/v2#Run
+	_replica, err := miniredis.Run()
+	if err != nil {
+		t.Errorf("unable to create primary miniredis instance: %v", err)
+	}
+	defer _replica.Close()
+
+	// create a local fake redis cluster
+	//
+	// https://pkg.go.dev/github.com/Bose/minisentinel#Run
+	_cluster, err := minisentinel.Run(_primary, minisentinel.WithReplica(_replica))
+	if err != nil {
+		t.Errorf("unable to create miniredis cluster: %v", err)
+	}
+	defer _cluster.Close()
+
+	tests := []struct {
+		address string
+		cluster bool
+		want    bool
+	}{
+		{
+			address: fmt.Sprintf("redis://%s,%s", _cluster.MasterInfo().Name, _cluster.Addr()),
+			cluster: true,
+			want:    true,
+		},
+		{
+			address: fmt.Sprintf("redis://%s", _cluster.Addr()),
+			cluster: false,
+			want:    false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_service, err := New(
+			WithAddress(test.address),
+			WithCluster(test.cluster),
+		)
+
+		if err != nil {
+			t.Errorf("WithCluster returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_service.config.Cluster, test.want) {
+			t.Errorf("WithCluster is %v, want %v", _service.config.Cluster, test.want)
+		}
+	}
+}

--- a/queue/redis/pop.go
+++ b/queue/redis/pop.go
@@ -13,12 +13,12 @@ import (
 
 // Pop grabs an item from the specified channel off the queue.
 func (c *client) Pop() (*types.Item, error) {
-	logrus.Tracef("popping item from queue %s", c.Channels)
+	logrus.Tracef("popping item from queue %s", c.config.Channels)
 
 	// build a redis queue command to pop an item from queue
 	//
 	// https://pkg.go.dev/github.com/go-redis/redis?tab=doc#Client.BLPop
-	popCmd := c.Queue.BLPop(0, c.Channels...)
+	popCmd := c.Queue.BLPop(0, c.config.Channels...)
 
 	// blocking call to pop item from queue
 	//

--- a/queue/redis/pop_test.go
+++ b/queue/redis/pop_test.go
@@ -50,7 +50,7 @@ func TestRedis_Pop_BadChannel(t *testing.T) {
 	c, _ := NewTest("vela")
 
 	// overwrite channel to be invalid
-	c.Channels = nil
+	c.config.Channels = nil
 
 	err := c.Queue.RPush("vela", nil).Err()
 	if err != nil {

--- a/queue/redis/push.go
+++ b/queue/redis/push.go
@@ -10,7 +10,7 @@ import (
 
 // Push inserts an item to the specified channel in the queue.
 func (c *client) Push(channel string, item []byte) error {
-	logrus.Tracef("pushing item to queue %s", c.Channels)
+	logrus.Tracef("pushing item to queue %s", channel)
 
 	// build a redis queue command to push an item to queue
 	//

--- a/queue/redis/redis.go
+++ b/queue/redis/redis.go
@@ -15,11 +15,11 @@ import (
 )
 
 type config struct {
-	// specifies the Redis address to use
+	// specifies the address to use for the Redis client
 	Address string
-	// specifies a list of channels for managing builds
+	// specifies a list of channels for managing builds for the Redis client
 	Channels []string
-	// enables the client to integrate with a Redis cluster
+	// enables the Redis client to integrate with a Redis cluster
 	Cluster bool
 }
 

--- a/queue/redis/redis.go
+++ b/queue/redis/redis.go
@@ -14,70 +14,67 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type client struct {
-	Queue    *redis.Client
-	Options  *redis.Options
+type config struct {
+	// specifies the Redis address to use
+	Address string
+	// specifies a list of channels for managing builds
 	Channels []string
+	// enables the client to integrate with a Redis cluster
+	Cluster bool
+}
+
+type client struct {
+	config  *config
+	Queue   *redis.Client
+	Options *redis.Options
 }
 
 // New returns a Queue implementation that
 // integrates with a Redis queue instance.
 //
 // nolint: golint // ignore returning unexported client
-func New(url string, channels ...string) (*client, error) {
+func New(opts ...ClientOpt) (*client, error) {
+	// create new Redis client
+	c := new(client)
+
+	// create new fields
+	c.config = new(config)
+	c.Queue = new(redis.Client)
+	c.Options = new(redis.Options)
+
+	// apply all provided configuration options
+	for _, opt := range opts {
+		err := opt(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// parse the url provided
-	options, err := redis.ParseURL(url)
+	options, err := redis.ParseURL(c.config.Address)
 	if err != nil {
 		return nil, err
 	}
 
-	// create the Redis client from the parsed url
-	queue := redis.NewClient(options)
+	// create the Redis options from the parsed url
+	c.Options = options
+
+	// check if clustering mode is enabled
+	if c.config.Cluster {
+		// create the Redis cluster client from the options
+		c.Queue = redis.NewFailoverClient(failoverFromOptions(c.Options))
+	} else {
+		// create the Redis client from the parsed url
+		c.Queue = redis.NewClient(c.Options)
+	}
 
 	// ping the queue
-	err = pingQueue(queue)
+	err = pingQueue(c.Queue)
 	if err != nil {
 		return nil, err
 	}
 
-	// create the client object
-	client := &client{
-		Queue:    queue,
-		Options:  options,
-		Channels: channels,
-	}
-
-	return client, nil
-}
-
-// NewCluster returns a Queue implementation that
-// integrates with a Redis queue cluster.
-//
-// nolint: golint // ignore returning unexported client
-func NewCluster(config string, channels ...string) (*client, error) {
-	// parse the url provided
-	options, err := redis.ParseURL(config)
-	if err != nil {
-		return nil, err
-	}
-
-	// create the Redis client from failover options
-	queue := redis.NewFailoverClient(failoverFromOptions(options))
-
-	// ping the queue
-	err = pingQueue(queue)
-	if err != nil {
-		return nil, err
-	}
-
-	// create the client object
-	client := &client{
-		Queue:    queue,
-		Options:  options,
-		Channels: channels,
-	}
-
-	return client, nil
+	return c, nil
 }
 
 // failoverFromOptions is a helper function to create
@@ -161,22 +158,17 @@ func pingQueue(client *redis.Client) error {
 //
 // nolint: golint // ignore returning unexported client
 func NewTest(channels ...string) (*client, error) {
-	// run a local fake redis instance
-	mr, err := miniredis.Run()
+	// create a local fake redis instance
+	//
+	// https://pkg.go.dev/github.com/alicebob/miniredis/v2#Run
+	_redis, err := miniredis.Run()
 	if err != nil {
 		return nil, err
 	}
 
-	// create the Redis client from the parsed url
-	queue := redis.NewClient(&redis.Options{
-		Addr: mr.Addr(),
-	})
-
-	// create the client object
-	client := &client{
-		Queue:    queue,
-		Channels: channels,
-	}
-
-	return client, nil
+	return New(
+		WithAddress(fmt.Sprintf("redis://%s", _redis.Addr())),
+		WithChannels(channels...),
+		WithCluster(false),
+	)
 }

--- a/queue/redis/redis_test.go
+++ b/queue/redis/redis_test.go
@@ -8,10 +8,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Bose/minisentinel"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-vela/sdk-go/vela"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
 )
@@ -121,86 +119,51 @@ var (
 	}
 )
 
-func TestRedis_New_Success(t *testing.T) {
-	// setup redis
-	redis, _ := miniredis.Run()
-
+func TestRedis_New(t *testing.T) {
 	// setup types
-	uri := fmt.Sprintf("redis://%s", redis.Addr())
 
-	// run test
-	_, err := New(uri, constants.DefaultRoute)
+	// create a local fake redis instance
+	//
+	// https://pkg.go.dev/github.com/alicebob/miniredis/v2#Run
+	_redis, err := miniredis.Run()
 	if err != nil {
-		t.Error("New should not have returned err: ", err)
+		t.Errorf("unable to create miniredis instance: %v", err)
 	}
-}
+	defer _redis.Close()
 
-func TestRedis_New_Failure(t *testing.T) {
-	// setup redis
-	redis, _ := miniredis.Run()
-
+	// setup tests
 	tests := []struct {
-		data string
-		want error
+		failure bool
+		address string
 	}{
-		{ // connection uri with invalid URI
-			data: redis.Addr(),
-			want: fmt.Errorf(""),
+		{
+			failure: false,
+			address: fmt.Sprintf("redis://%s", _redis.Addr()),
+		},
+		{
+			failure: true,
+			address: "",
 		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// run test
-		_, err := New(test.data, constants.DefaultRoute)
-		if err == nil {
-			t.Errorf("New should have returned err")
+		_, err := New(
+			WithAddress(test.address),
+			WithChannels("foo"),
+			WithCluster(false),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("New should have returned err")
+			}
+
+			continue
 		}
-	}
-}
 
-func TestRedis_NewCluster_Success(t *testing.T) {
-	// setup redis
-	replica, _ := miniredis.Run()
-	redis := minisentinel.NewSentinel(replica, minisentinel.WithReplica(replica))
-	_ = redis.Start()
-
-	// setup types
-	uri := fmt.Sprintf("redis://%s,%s", redis.MasterInfo().Name, redis.Addr())
-
-	// run test
-	_, err := NewCluster(uri, constants.DefaultRoute)
-	if err != nil {
-		t.Error("NewCluster should not have returned err: ", err)
-	}
-}
-
-func TestRedis_NewCluster_Failure(t *testing.T) {
-	// setup redis
-	replica, _ := miniredis.Run()
-	redis := minisentinel.NewSentinel(replica, minisentinel.WithReplica(replica))
-	_ = redis.Start()
-
-	tests := []struct {
-		data string
-		want error
-	}{
-		{ // connection uri with invalid URI
-			data: fmt.Sprintf("%s,%s", redis.MasterInfo().Name, redis.Addr()),
-			want: fmt.Errorf(""),
-		},
-		{ // connection uri that will timeout
-			data: fmt.Sprintf("redis://%s,%s", redis.MasterInfo().Name, "localhost"),
-			want: fmt.Errorf(""),
-		},
-	}
-
-	// run tests
-	for _, test := range tests {
-		// run test
-		_, err := New(test.data, constants.DefaultRoute)
-		if err == nil {
-			t.Errorf("New should have returned err")
+		if err != nil {
+			t.Errorf("New returned err: %v", err)
 		}
 	}
 }

--- a/queue/redis/route.go
+++ b/queue/redis/route.go
@@ -16,7 +16,7 @@ import (
 
 // Route decides which route a build gets placed within the queue.
 func (c *client) Route(w *pipeline.Worker) (string, error) {
-	logrus.Tracef("deciding route from queues %s", c.Channels)
+	logrus.Tracef("deciding route from queue channels %s", c.config.Channels)
 
 	// create buffer to store route
 	buf := bytes.Buffer{}

--- a/queue/redis/route_test.go
+++ b/queue/redis/route_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/go-vela/types/pipeline"
 )
 
-func TestDatabase_Client_Route(t *testing.T) {
+func TestRedis_Client_Route(t *testing.T) {
 	// setup
-	client, _ := NewTest()
+	client, _ := NewTest("vela")
 	tests := []struct {
 		want   string
 		worker pipeline.Worker


### PR DESCRIPTION
This adds a new way to create the `github.com/go-vela/pkg-queue/queue/redis` client used to integrate with queue systems.

A `../../../queue/redis.config{}` type has been added to store all required information to create the `redis` client:

https://github.com/go-vela/pkg-queue/blob/b8d40fcb540123ff81e36b2fc3d5a6a773f21d06/queue/redis/redis.go#L17-L24

A `../../../queue/redis.ClientOpt{}` type has been added to set the fields in the `config{}` type:

https://github.com/go-vela/pkg-queue/blob/b8d40fcb540123ff81e36b2fc3d5a6a773f21d06/queue/redis/opts.go#L13-L14

Also updated the `../../../queue/redis.New()` function to accept `...ClientOpt{}`:

https://github.com/go-vela/pkg-queue/blob/b8d40fcb540123ff81e36b2fc3d5a6a773f21d06/queue/redis/redis.go#L32-L78

Also the `../../../queue/redis.NewCluster()` function has been removed in favor of `redis.New()` handling clustering.