### PR TITLE
feat(queue): add context.Context to Push() and Pop()

### DIFF
--- a/queue/redis/pop.go
+++ b/queue/redis/pop.go
@@ -14,13 +14,13 @@ import (
 )
 
 // Pop grabs an item from the specified channel off the queue.
-func (c *client) Pop() (*types.Item, error) {
+func (c *client) Pop(ctx context.Context) (*types.Item, error) {
 	logrus.Tracef("popping item from queue %s", c.config.Channels)
 
 	// build a redis queue command to pop an item from queue
 	//
 	// https://pkg.go.dev/github.com/go-redis/redis?tab=doc#Client.BLPop
-	popCmd := c.Queue.BLPop(context.Background(), c.config.Timeout, c.config.Channels...)
+	popCmd := c.Queue.BLPop(ctx, c.config.Timeout, c.config.Channels...)
 
 	// blocking call to pop item from queue
 	//

--- a/queue/redis/push.go
+++ b/queue/redis/push.go
@@ -11,13 +11,13 @@ import (
 )
 
 // Push inserts an item to the specified channel in the queue.
-func (c *client) Push(channel string, item []byte) error {
+func (c *client) Push(ctx context.Context, channel string, item []byte) error {
 	logrus.Tracef("pushing item to queue %s", channel)
 
 	// build a redis queue command to push an item to queue
 	//
 	// https://pkg.go.dev/github.com/go-redis/redis?tab=doc#Client.RPush
-	pushCmd := c.Queue.RPush(context.Background(), channel, item)
+	pushCmd := c.Queue.RPush(ctx, channel, item)
 
 	// blocking call to push an item to queue and return err
 	//

--- a/queue/service.go
+++ b/queue/service.go
@@ -5,6 +5,8 @@
 package queue
 
 import (
+	"context"
+
 	"github.com/go-vela/types"
 	"github.com/go-vela/types/pipeline"
 )
@@ -14,11 +16,11 @@ import (
 type Service interface {
 	// Pop defines a function that grabs an
 	// item off the queue.
-	Pop() (*types.Item, error)
+	Pop(context.Context) (*types.Item, error)
 
 	// Push defines a function that publishes an
 	// item to the specified route in the queue.
-	Push(string, []byte) error
+	Push(context.Context, string, []byte) error
 
 	// Route defines a function that decides which
 	// channel a build gets placed within the queue.


### PR DESCRIPTION
Related to https://github.com/go-vela/pkg-queue/pull/43#issuecomment-796738773

This updates the `Push()` and `Pop()` functions for the `go-vela/pkg-queue/queue.Service{}` to accept `context.Context`:

https://github.com/go-vela/pkg-queue/blob/30fdcd44dbb0e7f624a267e31902f7bc8b469479/queue/service.go#L17-L23

Also updated the functions for the `go-vela/pkg-queue/queue/redis` package to accept `context.Context` as an argument:

https://github.com/go-vela/pkg-queue/blob/30fdcd44dbb0e7f624a267e31902f7bc8b469479/queue/redis/push.go#L13-L14

https://github.com/go-vela/pkg-queue/blob/30fdcd44dbb0e7f624a267e31902f7bc8b469479/queue/redis/pop.go#L16-L17

This will enable us to set a `timeout` when executing these calls as desired from https://github.com/go-vela/pkg-queue/pull/43.

> NOTE: Currently, all the code from the above PR is still in place and will be refactored out later.

Also updated the tests and refactored to table systel for the `../../../redis.Push()` and `../../../redis.Pop()` functions.