### PR TITLE
feat: add queue.Driver() function

### DIFF
--- a/queue/redis/driver.go
+++ b/queue/redis/driver.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package redis
+
+import "github.com/go-vela/types/constants"
+
+// Driver outputs the configured queue driver.
+func (c *client) Driver() string {
+	return constants.DriverRedis
+}

--- a/queue/redis/driver_test.go
+++ b/queue/redis/driver_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package redis
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-vela/types/constants"
+)
+
+func TestRedis_Driver(t *testing.T) {
+	// setup types
+
+	// create a local fake redis instance
+	//
+	// https://pkg.go.dev/github.com/alicebob/miniredis/v2#Run
+	_redis, err := miniredis.Run()
+	if err != nil {
+		t.Errorf("unable to create miniredis instance: %v", err)
+	}
+	defer _redis.Close()
+
+	want := constants.DriverRedis
+
+	_service, err := New(
+		WithAddress(fmt.Sprintf("redis://%s", _redis.Addr())),
+		WithChannels("foo"),
+		WithCluster(false),
+		WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Errorf("unable to create queue service: %v", err)
+	}
+
+	// run test
+	got := _service.Driver()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Driver is %v, want %v", got, want)
+	}
+}

--- a/queue/service.go
+++ b/queue/service.go
@@ -14,6 +14,12 @@ import (
 // Service represents the interface for Vela integrating
 // with the different supported Queue backends.
 type Service interface {
+	// Service Interface Functions
+
+	// Driver defines a function that outputs
+	// the configured queue driver.
+	Driver() string
+
 	// Pop defines a function that grabs an
 	// item off the queue.
 	Pop(context.Context) (*types.Item, error)


### PR DESCRIPTION
This adds a `Driver()` function to the `go-vela/pkg-queue/queue.Service` interface:

https://github.com/go-vela/pkg-queue/blob/6b5d227656ed73fb683982acedbff086d898f7f1/queue/service.go#L19-L21

And then we implement this function for each supported `queue` service:

https://github.com/go-vela/pkg-queue/blob/6b5d227656ed73fb683982acedbff086d898f7f1/queue/redis/driver.go#L9-L12