### PR TITLE
chore(docs): add migration disclaimer

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing
 
+> DISCLAIMER:
+>
+> This contents of this repository have been migrated into [go-vela/worker](https://github.com/go-vela/worker).
+>
+> This was done as a part of [go-vela/community#395](https://github.com/go-vela/community/issues/395) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
+
 We'd love to accept your contributions to this project! There are just a few guidelines you need to follow.
 
 ## Bugs

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 > DISCLAIMER:
 >
-> This contents of this repository have been migrated into [go-vela/worker](https://github.com/go-vela/worker).
+> This contents of this repository have been migrated into [go-vela/server](https://github.com/go-vela/server).
 >
 > This was done as a part of [go-vela/community#395](https://github.com/go-vela/community/issues/395) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 > DISCLAIMER:
 >
-> This contents of this repository have been migrated into [go-vela/server](https://github.com/go-vela/server).
+> The contents of this repository have been migrated into [go-vela/server](https://github.com/go-vela/server).
 >
-> This was done as a part of [go-vela/community#395](https://github.com/go-vela/community/issues/395) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
+> This was done as a part of [go-vela/community#394](https://github.com/go-vela/community/issues/394) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
 
 We'd love to accept your contributions to this project! There are just a few guidelines you need to follow.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,7 +2,7 @@
 
 > DISCLAIMER:
 >
-> This contents of this repository have been migrated into [go-vela/worker](https://github.com/go-vela/worker).
+> This contents of this repository have been migrated into [go-vela/server](https://github.com/go-vela/server).
 >
 > This was done as a part of [go-vela/community#395](https://github.com/go-vela/community/issues/395) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,9 +2,9 @@
 
 > DISCLAIMER:
 >
-> This contents of this repository have been migrated into [go-vela/server](https://github.com/go-vela/server).
+> The contents of this repository have been migrated into [go-vela/server](https://github.com/go-vela/server).
 >
-> This was done as a part of [go-vela/community#395](https://github.com/go-vela/community/issues/395) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
+> This was done as a part of [go-vela/community#394](https://github.com/go-vela/community/issues/394) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
 
 [![license](https://img.shields.io/crates/l/gl.svg)](../LICENSE)
 [![GoDoc](https://godoc.org/github.com/go-vela/pkg-queue?status.svg)](https://godoc.org/github.com/go-vela/pkg-queue)

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,11 @@
 # pkg-queue
 
+> DISCLAIMER:
+>
+> This contents of this repository have been migrated into [go-vela/worker](https://github.com/go-vela/worker).
+>
+> This was done as a part of [go-vela/community#395](https://github.com/go-vela/community/issues/395) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
+
 [![license](https://img.shields.io/crates/l/gl.svg)](../LICENSE)
 [![GoDoc](https://godoc.org/github.com/go-vela/pkg-queue?status.svg)](https://godoc.org/github.com/go-vela/pkg-queue)
 [![Go Report Card](https://goreportcard.com/badge/go-vela/pkg-queue)](https://goreportcard.com/report/go-vela/pkg-queue)


### PR DESCRIPTION
> Related to https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md
> 
> Part of the effort for https://github.com/go-vela/community/issues/395
> 
> This adds a disclaimer about the content of this repository being migrated to [go-vela/server](https://github.com/go-> vela/server).
> 
> After this is change is merged, the plan will to be archive this repository.